### PR TITLE
Allow empty RPC parameters and add get_space_usage support

### DIFF
--- a/TJDropbox/TJDropbox.h
+++ b/TJDropbox/TJDropbox.h
@@ -60,6 +60,10 @@ extern NSString *const TJDropboxErrorUserInfoKeyErrorString; // For error with T
 
 + (void)getSharedLinkForFileAtPath:(NSString *const)path accessToken:(NSString *const)accessToken completion:(void (^const)(NSString *_Nullable urlString))completion;
 
+// Users
+
++ (void)getSpaceUsageForUserWithAccessToken:(NSString *const)accessToken completion:(void (^const)(NSDictionary *_Nullable parsedResponse, NSError *_Nullable error))completion;
+
 // Request Management
 
 + (void)cancelAllRequests;

--- a/TJDropbox/TJDropbox.m
+++ b/TJDropbox/TJDropbox.m
@@ -394,9 +394,7 @@ NSString *const TJDropboxErrorUserInfoKeyErrorString = @"errorString";
 + (void)getSpaceUsageForUserWithAccessToken:(NSString *const)accessToken completion:(void (^const)(NSDictionary *_Nullable parsedResponse, NSError *_Nullable error))completion
 {
     NSURLRequest *const request = [self apiRequestWithPath:@"/2/users/get_space_usage" accessToken:accessToken parameters:nil];
-    [self performAPIRequest:request withCompletion:^(NSDictionary * _Nullable parsedResponse, NSError * _Nullable error) {
-        completion(parsedResponse, error);
-    }];
+    [self performAPIRequest:request withCompletion:completion];
 }
 
 #pragma mark - Request Management

--- a/TJDropbox/TJDropbox.m
+++ b/TJDropbox/TJDropbox.m
@@ -389,6 +389,16 @@ NSString *const TJDropboxErrorUserInfoKeyErrorString = @"errorString";
     }];
 }
 
+#pragma mark - Users
+
++ (void)getSpaceUsageForUserWithAccessToken:(NSString *const)accessToken completion:(void (^const)(NSDictionary *_Nullable parsedResponse, NSError *_Nullable error))completion
+{
+    NSURLRequest *const request = [self apiRequestWithPath:@"/2/users/get_space_usage" accessToken:accessToken parameters:nil];
+    [self performAPIRequest:request withCompletion:^(NSDictionary * _Nullable parsedResponse, NSError * _Nullable error) {
+        completion(parsedResponse, error);
+    }];
+}
+
 #pragma mark - Request Management
 
 + (void)cancelAllRequests

--- a/TJDropbox/TJDropbox.m
+++ b/TJDropbox/TJDropbox.m
@@ -135,8 +135,12 @@ NSString *const TJDropboxErrorUserInfoKeyErrorString = @"errorString";
 + (NSURLRequest *)apiRequestWithPath:(NSString *const)path accessToken:(NSString *const)accessToken parameters:(NSDictionary<NSString *, NSString *> *const)parameters
 {
     NSMutableURLRequest *const request = [self requestWithBaseURLString:@"https://api.dropboxapi.com" path:path accessToken:accessToken];
-    [request addValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
     request.HTTPBody = [[self parameterStringForParameters:parameters] dataUsingEncoding:NSUTF8StringEncoding];
+    
+    if (request.HTTPBody != nil) {
+        [request addValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+    }
+    
     return request;
 }
 


### PR DESCRIPTION
Here's my first attempt at the changes mentioned in #8. I've been thinking that maybe the callback from getSpaceUsage should be a little richer than just a parsed JSON, since this requires a little more intimate knowledge of the API. But of course keeping the library simple is also a good thing, probably. :)
