### PR TITLE
Add support for refresh tokens when using app auth

### DIFF
--- a/TJDropbox/TJDropbox.h
+++ b/TJDropbox/TJDropbox.h
@@ -96,7 +96,7 @@ __attribute__((objc_direct_members))
 /// Used to return the URL used to initiate authentication with the installed Dropbox app
 + (NSURL *)dropboxAppAuthenticationURLWithClientIdentifier:(NSString *const)clientIdentifier
                                               codeVerifier:(nullable NSString *const)codeVerifier
-									  generateRefreshToken:(const BOOL)generateRefreshToken;
+                                      generateRefreshToken:(const BOOL)generateRefreshToken;
 
 /// Used to extract the access token from Dropbox app authentication
 + (nullable TJDropboxCredential *)credentialFromDropboxAppAuthenticationURL:(NSURL *const)url;

--- a/TJDropbox/TJDropbox.h
+++ b/TJDropbox/TJDropbox.h
@@ -95,7 +95,8 @@ __attribute__((objc_direct_members))
 
 /// Used to return the URL used to initiate authentication with the installed Dropbox app
 + (NSURL *)dropboxAppAuthenticationURLWithClientIdentifier:(NSString *const)clientIdentifier
-                                              codeVerifier:(nullable NSString *const)codeVerifier;
+                                              codeVerifier:(nullable NSString *const)codeVerifier
+									  generateRefreshToken:(const BOOL)generateRefreshToken;
 
 /// Used to extract the access token from Dropbox app authentication
 + (nullable TJDropboxCredential *)credentialFromDropboxAppAuthenticationURL:(NSURL *const)url;

--- a/TJDropbox/TJDropboxAuthenticator.h
+++ b/TJDropbox/TJDropboxAuthenticator.h
@@ -12,7 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface TJDropboxAuthenticationOptions : NSObject
 
 /// Credentials will be long-lived.
-- (instancetype)initWithGenerateRefreshToken;
+- (instancetype)initWithGenerateRefreshToken:(BOOL)generateRefreshToken
+                            bypassNativeAuth:(const BOOL)bypassNativeAuth;
 
 /// Credentials will be short-lived after Sept. 30 2021 https://developers.dropbox.com/oauth-guide#using-refresh-tokens
 - (instancetype)initWithBypassNativeAuth:(const BOOL)bypassNativeAuth

--- a/TJDropbox/TJDropboxAuthenticator.m
+++ b/TJDropbox/TJDropboxAuthenticator.m
@@ -22,10 +22,11 @@
 
 @implementation TJDropboxAuthenticationOptions
 
-- (instancetype)initWithGenerateRefreshToken {
+- (instancetype)initWithGenerateRefreshToken:(BOOL)generateRefreshToken
+                            bypassNativeAuth:(const BOOL)bypassNativeAuth {
     if (self = [super init]) {
-        _generateRefreshToken = YES;
-        _bypassNativeAuth = YES;
+        _generateRefreshToken = generateRefreshToken;
+        _bypassNativeAuth = bypassNativeAuth;
     }
     return self;
 }
@@ -127,7 +128,8 @@ static void (^_tj_completion)(TJDropboxCredential *);
                                                completion:completion];
     } else {
         NSURL *const tokenAuthURL = [TJDropbox dropboxAppAuthenticationURLWithClientIdentifier:clientIdentifier
-                                                                                  codeVerifier:codeVerifier];
+                                                                                  codeVerifier:codeVerifier
+                                                                          generateRefreshToken:options.generateRefreshToken];
         [[UIApplication sharedApplication] openURL:tokenAuthURL
                                            options:@{}
                                  completionHandler:^(BOOL success) {


### PR DESCRIPTION
Use the following authentication options to use native app auth with refresh tokens:  

```objc
[[TJDropboxAuthenticationOptions alloc] initWithGenerateRefreshToken:YES bypassNativeAuth:NO]
```